### PR TITLE
removing $scope and fixing small angular bugs

### DIFF
--- a/app/assets/javascripts/events_ctrl.coffee
+++ b/app/assets/javascripts/events_ctrl.coffee
@@ -1,71 +1,75 @@
-angular.module('plastic-disco').controller 'EventsCtrl', ['$scope', '$http', ($scope, $http) ->
-  $scope.sort = 'desc'
+EventsController = ($http) ->
+  vm = this
 
-  $scope.loadEvents = ->
-    $scope.loading = true
-    params = { query: $scope.query, sort: $scope.sort }
-    if $scope.requireVideo
+  vm.sort = 'desc'
+
+  vm.loadEvents = ->
+    vm.loading = true
+    params = { query: vm.query, sort: vm.sort }
+    if vm.requireVideo
       params.require_video = true
     $http.get '/events/search.json', params: params
     .success (data) ->
-      $scope.events = data
-      $scope.loading = false
+      vm.events = data
+      vm.loading = false
 
-  $scope.loadMore = ->
-    params = { query: $scope.query, offset: $scope.events.lengt, sort: $scope.sort  }
-    if $scope.requireVideo
+  vm.loadMore = ->
+    params = { query: vm.query, offset: vm.events.length, sort: vm.sort  }
+    if vm.requireVideo
       params.require_video = true
     $http.get '/events/search.json', params: params
     .success (data) ->
-      $scope.events = $scope.events.concat data
+      vm.events = vm.events.concat data
 
-  $scope.typing = _.debounce $scope.loadEvents, 200
+  vm.typing = _.debounce vm.loadEvents, 200
 
-  $scope.seekTo = (event) ->
+  vm.seekTo = (event) ->
     loc = event.starts_at_since_epoch - video.starts_at_since_epoch
     window.seek loc
 
-
   # This stuff only happens on videos#show
 
-  $scope.select = (event) ->
-    $scope.selectedEvent = event
+  vm.select = (event) ->
+    vm.selectedEvent = event
 
-  $scope.clearSelection = ->
-    $scope.selectedEvent = null
+  vm.clearSelection = ->
+    vm.selectedEvent = null
 
-  $scope.alignWithoutEvent = ->
-    $http.put "/videos/#{$scope.video_id}.json", video: { aligned: true }
+  vm.alignWithoutEvent = ->
+    $http.put "/videos/#{vm.video_id}.json", video: { aligned: true }
     .success (data) ->
       alert "Success! Refreshing the page now for review..."
       location.reload()
     .error ->
       alert "Failure!"
 
-  $scope.alignWithSelectedEvent = ->
+  vm.alignWithSelectedEvent = ->
     event.starts_at
-    $http.post "/videos/#{$scope.video_id}/align_to_event.json", { event_id: $scope.selectedEvent.id, seconds_into_clip: $scope.secondsIntoClip, minutes_into_clip: $scope.minutesIntoClip }
+    $http.post "/videos/#{vm.video_id}/align_to_event.json", { event_id: vm.selectedEvent.id, seconds_into_clip: vm.secondsIntoClip, minutes_into_clip: vm.minutesIntoClip }
     .success (data) ->
       alert "Success! Refreshing the page now for review..."
       location.reload()
     .error (data) ->
       alert "Failure! Did you input seconds and minutes?"
 
-  $scope.saveOffset = ->
-    $http.post "/videos/#{$scope.video_id}/offset.json", offset: $scope.offset
+  vm.saveOffset = ->
+    debugger
+    $http.post "/videos/#{vm.video_id}/offset.json", offset: vm.offset
     .success (data) ->
       alert "Success! Refreshing the page now for review..."
       location.reload()
     .error ->
       alert "Failure!"
 
-  $scope.init = (video_id, options = {}) ->
+  vm.init = (video_id, options = {}) ->
     # only videos#show uses the init function
-    $scope.video_id = video_id
-    $http.get("/videos/#{video_id}.json").success (d) -> $scope.video = d
-    $scope.sort = options.sort if options.sort?
-    $scope.loadEvents()
+    vm.video_id = video_id
+    $http.get("/videos/#{video_id}.json").success (d) -> vm.video = d
+    vm.sort = options.sort if options.sort?
+    vm.loadEvents()
 
-  $scope.loadEvents()
+  vm.loadEvents()
 
-]
+EventsController.$inject = ['$http']
+
+angular.module('plastic-disco').controller 'EventsCtrl', EventsController

--- a/app/assets/javascripts/video_player_ctrl.coffee
+++ b/app/assets/javascripts/video_player_ctrl.coffee
@@ -1,31 +1,34 @@
-angular.module('plastic-disco').controller 'VideoPlayerCtrl', ['$scope', '$http', '$element', ($scope, $http, $element) ->
-  $scope.highlight = {}
+VideoPlayerController = ($http, $element) ->
 
-  $scope.init = (video_id) ->
-    $scope.video_id = video_id
+  vm = this
+  vm.highlight = {}
+
+  vm.init = (video_id) ->
+    vm.video_id = video_id
     $http.get("/videos/#{video_id}.json").success (d) ->
-      $scope.video = d
-      console.log d
+      vm.video = d
 
-  $scope.createHighlight = ->
-    $scope.highlight.video_id = $scope.video_id
-    $scope.highlight.offset = ($scope.highlight.startMinutes||0)*60 + $scope.highlight.startSeconds
-    $scope.highlight.duration = (($scope.highlight.endMinutes||0)*60 + $scope.highlight.endSeconds) - $scope.highlight.offset
-    $http.post '/highlights.json', highlight: $scope.highlight
+  vm.createHighlight = ->
+    vm.highlight.video_id = vm.video_id
+    vm.highlight.offset = (vm.highlight.startMinutes||0)*60 + vm.highlight.startSeconds
+    vm.highlight.duration = ((vm.highlight.endMinutes||0)*60 + vm.highlight.endSeconds) - vm.highlight.offset
+    $http.post '/highlights.json', highlight: vm.highlight
     .success (highlight) ->
-      $scope.video.highlights or= []
-      $scope.video.highlights.unshift highlight
-      $scope.highlight = {}
-      $scope.highlightFormVisible = false
+      vm.video.highlights or= []
+      vm.video.highlights.unshift highlight
+      vm.highlight = {}
+      vm.highlightFormVisible = false
     .error (data) ->
       alert "Failure! #{data.join('. ')}"
 
-  $scope.jumpToHighlight = (highlight) ->
-    console.log highlight
+  vm.jumpToHighlight = (highlight) ->
     iframe = $($element).find('iframe')
     src = iframe.attr 'src'
     without_params = src.replace /\?.*/, ''
     with_new_params = "#{without_params}?start=#{highlight.offset}&end=#{highlight.offset+highlight.duration}&autoplay=1&loop=1"
     iframe.attr 'src', with_new_params
     0 # return 0 so angular doesn't yell at your for DOM manipulation
-]
+
+VideoPlayerController.$inject = ["$http", "$element"]
+
+angular.module('plastic-disco').controller 'VideoPlayerCtrl', VideoPlayerController

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -8,32 +8,32 @@
       \/
       = link_to 'Video archive', videos_path
 
-.row(ng-controller='EventsCtrl' ng-cloak)
+.row(ng-controller='EventsCtrl as eventsCtrl' ng-cloak)
   .col-md-8.col-md-offset-2
 
     .form-group
-      %input.form-control(ng-model='query' ng-keydown='typing()' placeholder='Search by game, player, date, anything' init-value-from-view)
+      %input.form-control(ng-model='eventsCtrl.query' ng-keydown='eventsCtrl.typing()' placeholder='Search by game, player, date, anything' init-value-from-view)
       .row.help-block.form-inline
         .col-md-6
           .radio
             %label
-              %input(type='radio' name='sort' ng-model='sort' value='desc' ng-change='loadEvents()')
+              %input(type='radio' name='sort' ng-model='eventsCtrl.sort' value='desc' ng-change='eventsCtrl.loadEvents()')
               %small Most recent first
           &nbsp;
           .radio
             %label
-              %input(type='radio' name='sort' ng-model='sort' value='asc' ng-change='loadEvents()')
+              %input(type='radio' name='sort' ng-model='eventsCtrl.sort' value='asc' ng-change='eventsCtrl.loadEvents()')
               %small Oldest first
         .col-md-6.text-right
           .checkbox
             %label
-              %input(type='checkbox' ng-model='requireVideo' ng-change='loadEvents()')
+              %input(type='checkbox' ng-model='eventsCtrl.requireVideo' ng-change='eventsCtrl.loadEvents()')
               %small Only show plays with videos
 
 
 
     .event-list(ng-class='loading ? "transparent" : ""')
-      %div(ng-repeat='event in events')
+      %div(ng-repeat='event in eventsCtrl.events')
         .pull-right
           %small.text-muted
             {{event.kind}}, {{event.starts_at}}
@@ -46,5 +46,5 @@
         %hr
 
       .text-center
-        %a.btn.btn-default(ng-click='loadMore()') Show more
+        %a.btn.btn-default(ng-click='eventsCtrl.loadMore()') Show more
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -17,12 +17,12 @@
           - if seek / 60 > 0
             #{seek / 60} minutes,
           #{seek % 60} seconds into this video
-        
+
       %p
         #{@event.title}
       %hr
 
-      .video(ng-controller='VideoPlayerCtrl' ng-init="init(#{video.id})")
+      .video(ng-controller='VideoPlayerCtrl as videoPlayerCtrl' ng-init="videoPlayerCtrl.init(#{video.id})")
         .form-group
           .video-container
             - if video.youtube_id.present?
@@ -33,35 +33,35 @@
           .col-sm-6
             %h3 Highlights in this video
             %p
-              %a(href='javascript:void(0);' ng-click='highlightFormVisible = !highlightFormVisible')
+              %a(href='javascript:void(0);' ng-click='videoPlayerCtrl.highlightFormVisible = !videoPlayerCtrl.highlightFormVisible')
                 %small add new highlight
 
-            %form(ng-show='highlightFormVisible' ng-submit='createHighlight()' ng-disabled='savingHighlight')
+            %form(ng-show='videoPlayerCtrl.highlightFormVisible' ng-submit='videoPlayerCtrl.createHighlight()' ng-disabled='videoPlayerCtrl.savingHighlight')
 
               .form-group
                 %p When should the highlight start?
-                %input.form-control(type='number' ng-model='highlight.startMinutes' style='display: inline-block; width: 100px;' placeholder='min')
-                %input.form-control(type='number' ng-model='highlight.startSeconds' style='display: inline-block; width: 100px;' placeholder='sec')
+                %input.form-control(type='number' ng-model='videoPlayerCtrl.highlight.startMinutes' style='display: inline-block; width: 100px;' placeholder='min')
+                %input.form-control(type='number' ng-model='videoPlayerCtrl.highlight.startSeconds' style='display: inline-block; width: 100px;' placeholder='sec')
 
               .form-group
                 %p When should the highlight end?
-                %input.form-control(type='number' ng-model='highlight.endMinutes' style='display: inline-block; width: 100px;' placeholder='min')
-                %input.form-control(type='number' ng-model='highlight.endSeconds' style='display: inline-block; width: 100px;' placeholder='sec')
+                %input.form-control(type='number' ng-model='videoPlayerCtrl.highlight.endMinutes' style='display: inline-block; width: 100px;' placeholder='min')
+                %input.form-control(type='number' ng-model='videoPlayerCtrl.highlight.endSeconds' style='display: inline-block; width: 100px;' placeholder='sec')
 
               .form-group
                 %p What should it be called?
-                %input.form-control(ng-model='highlight.title' placeholder='Cookie Monster with the HUGE layout D!')
+                %input.form-control(ng-model='videoPlayerCtrl.highlight.title' placeholder='Cookie Monster with the HUGE layout D!')
 
 
               .form-group
-                %button.btn.btn-primary {{ savingHighlight ? 'Saving...' : 'Save highlight' }}
+                %button.btn.btn-primary {{ videoPlayerCtrl.savingHighlight ? 'Saving...' : 'Save highlight' }}
 
-                
-            %p(ng-repeat='highlight in video.highlights')
+
+            %p(ng-repeat='highlight in videoPlayerCtrl.video.highlights')
               {{highlight.title}}
-              %a(href='javascript:void(0);' ng-click='jumpToHighlight(highlight)')
+              %a(href='javascript:void(0);' ng-click='videoPlayerCtrl.jumpToHighlight(highlight)')
                 %small jump to this highlight
-                  
+
           .col-sm-6.text-right
             %small= link_to 'explore this video &raquo;'.html_safe, video_path(video)
         %br

--- a/app/views/videos/show.html.haml
+++ b/app/views/videos/show.html.haml
@@ -26,7 +26,7 @@
           %i.fa.fa-check
           This video has been manually aligned.
           %small= link_to 'remove alignment', unalign_video_path(@video), method: :post
-      
+
 
         %p
           %strong Manually aligned timestamps
@@ -53,22 +53,22 @@
 
   .col-md-4
     - if current_user and @video.user_id == current_user.id
-      %div(ng-controller='EventsCtrl' ng-init="init('#{@video.id}', { sort: 'asc' })")
+      %div(ng-controller='EventsCtrl as eventsCtrl' ng-init="eventsCtrl.init('#{@video.id}', { sort: 'asc' })")
 
-        %div(ng-show='!aligningVideo')
+        %div(ng-show='!eventsCtrl.aligningVideo')
           %p
             Here's the current event stream near this video.
             %br
             %small.text-muted
               - if @video.aligned?
                 Look incorrect?
-                %a(href='javascript:void(0);' ng-click='aligningVideo = true') Re-align it.
+                %a(href='javascript:void(0);' ng-click='eventsCtrl.aligningVideo = true') Re-align it.
               - else
                 - if @video.starts_at
                   Look right?
-                  %a(href='javascript:void(0);' ng-click='alignWithoutEvent()') Mark it as aligned.
+                  %a(href='javascript:void(0);' ng-click='eventsCtrl.alignWithoutEvent()') Mark it as aligned.
                 Look wrong?
-                %a(href='javascript:void(0);' ng-click='aligningVideo = true') Align it.
+                %a(href='javascript:void(0);' ng-click='eventsCtrl.aligningVideo = true') Align it.
 
           - if @video.events.blank?
             %hr
@@ -89,7 +89,7 @@
 
 
 
-        %div(ng-show='aligningVideo')
+        %div(ng-show='eventsCtrl.aligningVideo')
 
           %p
             Align this video
@@ -99,20 +99,20 @@
               you've found a matching event, tell us exactly when it happens in this video.
               Then the whole video will be aligned.
               %br
-              %a(href='javascript:void(0);' ng-click='settingOffset = true') Set offset directly
+              %a(href='javascript:void(0);' ng-click='eventsCtrl.settingOffset = true') Set offset directly
               \/
-              %a(href='javascript:void(0);' ng-click='aligningVideo = false') Cancel
+              %a(href='javascript:void(0);' ng-click='eventsCtrl.aligningVideo = false; eventsCtrl.settingOffset = false') Cancel
 
 
-          %div(ng-show='!selectedEvent && !settingOffset')
+          %div(ng-show='!eventsCtrl.selectedEvent && !eventsCtrl.settingOffset')
             .form-group
-              %input.form-control(ng-model='query' ng-keydown='typing()' placeholder='Search here')
+              %input.form-control(ng-model='eventsCtrl.query' ng-keydown='eventsCtrl.typing()' placeholder='Search here')
 
 
-            %div(ng-repeat='event in events')
+            %div(ng-repeat='event in eventsCtrl.events')
               .pull-right
                 %small
-                  %a(ng-click='select(event)' href='javascript:void(0);') select
+                  %a(ng-click='eventsCtrl.select(event)' href='javascript:void(0);') select
 
               %p
                 {{event.title}}
@@ -124,35 +124,35 @@
               %hr
 
             .text-center
-              %a.btn.btn-default(ng-click='loadMore()') Show more
+              %a.btn.btn-default(ng-click='eventsCtrl.loadMore()') Show more
 
-          %div(ng-show='selectedEvent && !settingOffset')
+          %div(ng-show='eventsCtrl.selectedEvent && !eventsCtrl.settingOffset')
             %hr
 
             .pull-right
               %small.text-muted
-                {{selectedEvent.kind}}, {{selectedEvent.starts_at}}
-                %span(ng-if='selectedEvent.ends_at') - {{selectedEvent.ends_at}}
+                {{eventsCtrl.selectedEvent.kind}}, {{eventsCtrl.selectedEvent.starts_at}}
+                %span(ng-if='eventsCtrl.selectedEvent.ends_at') - {{eventsCtrl.selectedEvent.ends_at}}
 
             %p
-              {{selectedEvent.title}}
+              {{eventsCtrl.selectedEvent.title}}
               %small
-                %a(ng-click='clearSelection()' href='javascript:void(0);') cancel selection
+                %a(ng-click='eventsCtrl.clearSelection()' href='javascript:void(0);') cancel selection
             %hr
 
             %p When does this play happen in the clip?
 
-            %form(ng-submit='alignWithSelectedEvent()')
+            %form(ng-submit='eventsCtrl.alignWithSelectedEvent()')
               .form-group
-                %input.form-control(ng-model='minutesIntoClip' style='display: inline-block; width: 100px;' placeholder='min' type='number')
-                %input.form-control(ng-model='secondsIntoClip' style='display: inline-block; width: 100px;' placeholder='sec' type='number')
+                %input.form-control(ng-model='eventsCtrl.minutesIntoClip' style='display: inline-block; width: 100px;' placeholder='min' type='number')
+                %input.form-control(ng-model='eventsCtrl.secondsIntoClip' style='display: inline-block; width: 100px;' placeholder='sec' type='number')
                 %button.btn.btn-default Save
 
-          %div(ng-show='settingOffset')
-            %form(ng-submit='saveOffset()')
+          %div(ng-show='eventsCtrl.settingOffset')
+            %form(ng-submit='eventsCtrl.saveOffset()')
               .form-group
                 %p Enter the number of seconds to offset this video from it's <em>original start time</em>. Negative numbers move it backwards.
-                %input.form-control(ng-model='offset' required type='number')
+                %input.form-control(ng-model='eventsCtrl.offset' required type='number')
 
               .form-group
                 %button.btn.btn-default Save


### PR DESCRIPTION
Took out $scope and made a couple small changes (spelling of length, taking out some console.logs and making sure that if you press 'cancel' when manually setting an offset you go back to the original state). I haven't tested everything so you'd know better if I made a change that broke things. Happy to put this on a feature branch if you want too. 
